### PR TITLE
feat: adds transform step with total sells by product and data cleaning

### DIFF
--- a/documents/transformed_data.csv
+++ b/documents/transformed_data.csv
@@ -1,0 +1,5 @@
+Data da Venda,Produto,Quantidade Vendida,Valor Unitário,Observações,Total da Venda
+2024-01-01,Produto A,10.0,5.5,,55.0
+2024-01-01,Produto A,10.0,5.5,,55.0
+2024-01-02,Produto B,8.0,12.0,,96.0
+2024-01-03,Produto C,5.0,7.25,,36.25

--- a/etl/extract.py
+++ b/etl/extract.py
@@ -1,7 +1,7 @@
 import os
 import pandas as pd
 
-def extract_csv_data(folder: str) -> pd.DataFrame:
+def extract_data(folder: str) -> pd.DataFrame:
     if not os.path.exists(folder):
         raise FileNotFoundError(f'Folder {folder} was not searched')
     files = [f for f in os.listdir(folder) if f.endswith('.csv')]

--- a/etl/transform.py
+++ b/etl/transform.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+def transform_data(df: pd.DataFrame) -> pd.DataFrame:
+    df['Quantidade Vendida'] = pd.to_numeric(df['Quantidade Vendida'], errors='coerce')
+    df['Valor Unitário'] = pd.to_numeric(df['Valor Unitário'])
+
+    df['Total da Venda'] = df['Quantidade Vendida'] * df['Valor Unitário']
+
+    # delete rows with missing in data keys columns
+    df = df.dropna(subset=['Data da Venda', 'Produto', 'Quantidade Vendida', 'Valor Unitário'])
+
+    df['Data da Venda'] = pd.to_datetime(df['Data da Venda'], errors='coerce')
+    df.dropna(subset=['Data da Venda'])
+
+    print('Data transformed')
+    return df
+    

--- a/main.py
+++ b/main.py
@@ -1,8 +1,13 @@
-from etl.extract import extract_csv_data
+from etl.extract import extract_data
+from etl.transform import transform_data
 
 data_path = 'data'
-outpu_path = 'documents/all_data.csv'
+output_folder = 'documents/'
 
-df = extract_csv_data(data_path)
-df.to_csv(outpu_path, index=False)
-print(f'All data saved in: {outpu_path}')
+df = extract_data(data_path)
+df.to_csv(output_folder + 'all_data.csv', index=False)
+print(f'All data saved in: {output_folder + "all_data.csv"}')
+
+df_transformed = transform_data(df)
+df_transformed.to_csv(f'{output_folder + "transformed_data.csv"}', index=False)
+print(f'Transformed data saved in: {output_folder + "transformed_data.csv"}')


### PR DESCRIPTION
Implements the transformation step phase of the ETL process after data extraction.
Adds a `transform_data()` function that:
- calculates a new columns `Valor Total da Venda` as `Quantidade Vendida * Valor Unitário`
- Drops rows with missing or invalid values
- Standardizes column formats for consistency

This prepares the dataset for the loading phase into SQLite database